### PR TITLE
Update Helper.cs

### DIFF
--- a/SNET.Core/Helper.cs
+++ b/SNET.Core/Helper.cs
@@ -42,7 +42,9 @@ namespace SNET.Core
                     throw null; 
                 ConnectionManager instance = ConnectionManager.Instance;
                 instance.GetConnection(config, result.ToString());
-
+                
+                ServicePointManager.Expect100Continue = false;
+                
                 HttpWebRequest connection = CreateHttpWebRequestConnection(config, httpMethod, result, instance);
 
                 SetHttpHeaders(headerMap, connection);


### PR DESCRIPTION
Expect100Continue should be disabled in http requests, otherwise some api calls, such as vault customer update, will always fail